### PR TITLE
Align to ux specs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-canary
+  - env: EMBER_TRY_SCENARIO=ember-beta
 before_install:
 - npm config set spin false
 - npm install -g coveralls pr-bumper

--- a/addon/styles/_frost-sidebar.scss
+++ b/addon/styles/_frost-sidebar.scss
@@ -19,11 +19,32 @@
   }
 
   .pod {
-    padding: 25px;
-    // Value of '1' below hides the content behind this pod completely.
-    background-color: rgba($frost-color-white, 1);
+    padding: 5px;
+    background-color: $frost-color-white;
     box-shadow: 1px 3px 15px $frost-color-grey-5;
-    z-index: $frost-z-index-application-bar;
+    z-index: $frost-z-index-modal;
+
+    // Kick in the scroll bar after these max height and widths
+    // of the pod.
+    .frost-scroll {
+      max-height: 550px;
+      max-width: 330px;
+      .pod-content {
+        padding: 20px;
+        margin-right: 20px;
+        margin-bottom: 20px
+      }
+
+      .ps-scrollbar-x-rail{
+        background-color: $frost-color-white;
+        position:relative;
+      }
+
+      .ps-scrollbar-y-rail{
+        background-color: $frost-color-white;
+        position:absolute;
+      }
+    }
   }
 
   .tab {
@@ -34,7 +55,7 @@
     cursor: pointer;
     box-shadow: 1px 2px 5px $frost-color-grey-5;
     background-color: $frost-color-white;
-    z-index: $frost-z-index-application-bar;
+    z-index: $frost-z-index-modal;
 
     .icon {
       width: 50px;
@@ -46,6 +67,7 @@
     background-color: $frost-color-night-3;
   }
 }
+
 .frost-sidebar .tab:hover:not(.tab-open) {
   padding-left: 10px;
   width: 65px;

--- a/addon/styles/_frost-sidebar.scss
+++ b/addon/styles/_frost-sidebar.scss
@@ -1,62 +1,52 @@
-.frost-sidebar .container {
-  width: 100%;
-  height: 100%;
-}
-
 .frost-sidebar {
   position: absolute;
-  left: 0;
-}
+  left: 0px;
 
-.frost-sidebar .liquid-container > .liquid-child {
-  width: 100%;
-  height: 100%;
-}
+  .liquid-container > .liquid-child {
+    width: auto;
+    height: auto;
+  }
 
-.frost-sidebar .open-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  min-width: 200px;
-  min-height: 155px;
-  width: 100%;
-  height: 100%;
-}
+  .open-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+  }
 
-.frost-sidebar .closed-container {
-  width: 70px;
-  height: 65px;
-}
+  .closed-container {
+    width: 70px;
+    height: 65px;
+  }
 
-.frost-sidebar .pod {
-  height: calc(100% - 8px);
-  width: calc(100% - 58px);
-  background-color: rgba($frost-color-white, 0.95);
-  box-shadow: 1px 3px 15px $frost-color-grey-5;
-  z-index: $frost-z-index-application-bar;
-  overflow: auto;
-}
+  .pod {
+    padding: 25px;
+    // Value of '1' below hides the content behind this pod completely.
+    background-color: rgba($frost-color-white, 1);
+    box-shadow: 1px 3px 15px $frost-color-grey-5;
+    z-index: $frost-z-index-application-bar;
+  }
 
-.frost-sidebar .tab {
-  width: 55px;
-  height: 60px;
-  border-radius: 4px;
-  cursor: pointer;
-  box-shadow: 1px 2px 5px $frost-color-grey-5;
-  background-color: $frost-color-white;
-  z-index: $frost-z-index-application-bar;
-}
+  .tab {
+    padding-top: 6px;
+    width: 55px;
+    height: 60px;
+    border-radius: 4px;
+    cursor: pointer;
+    box-shadow: 1px 2px 5px $frost-color-grey-5;
+    background-color: $frost-color-white;
+    z-index: $frost-z-index-application-bar;
 
-.frost-sidebar .tab-open {
-  background-color: $frost-color-night-3;
-}
+    .icon {
+      width: 50px;
+      height: 50px;
+    }
+  }
 
+  .tab-open {
+    background-color: $frost-color-night-3;
+  }
+}
 .frost-sidebar .tab:hover:not(.tab-open) {
   padding-left: 10px;
-}
-
-.frost-sidebar .tab .icon {
-  padding: 7px;
-  width: 45px;
-  height: 45px;
+  width: 65px;
 }

--- a/addon/templates/components/frost-sidebar.hbs
+++ b/addon/templates/components/frost-sidebar.hbs
@@ -1,9 +1,12 @@
 {{#liquid-if isOpen class="container" }}
   <div class="open-container">
     <div class="pod">
-      {{yield}}
+      {{#frost-scroll}}
+        <div class="pod-content">
+          {{yield}}
+        </div>
+      {{/frost-scroll}}
     </div>
-
     <div class="tab tab-open" {{action (action 'toggleSidebar')}}>
       {{frost-icon class="icon" icon="frost/sidebar-layer-open"}}
     </div>

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-mocha": "~0.8.11",
     "Faker": "3.0.1",
     "lodash": "^4.10.0",
-    "perfect-scrollbar": "~0.6.7",
+    "perfect-scrollbar": "~0.6.10",
     "pretender": "~0.12.0",
     "sinonjs": "1.17.1",
     "jquery": "2.1.4"

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-mocha": "~0.8.11",
     "Faker": "3.0.1",
     "lodash": "^4.10.0",
-    "perfect-scrollbar": ">=0.6.7 <2.0.0",
+    "perfect-scrollbar": "^0.6.12",
     "pretender": "~0.12.0",
     "sinonjs": "1.17.1",
     "jquery": "2.1.4"

--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,8 @@
     "ember-inflector": "1.3.1",
     "ember-mocha": "~0.8.11",
     "Faker": "3.0.1",
-    "lodash": "~4.5.0",
-    "perfect-scrollbar": "~0.6.10",
+    "lodash": "^4.10.0",
+    "perfect-scrollbar": ">=0.6.7 <2.0.0",
     "pretender": "~0.12.0",
     "sinonjs": "1.17.1",
     "jquery": "2.1.4"

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-mocha": "~0.8.11",
     "Faker": "3.0.1",
     "lodash": "^4.10.0",
-    "perfect-scrollbar": "^0.6.12",
+    "perfect-scrollbar": "~0.6.7",
     "pretender": "~0.12.0",
     "sinonjs": "1.17.1",
     "jquery": "2.1.4"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-computed-decorators": "^0.2.2",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-frost-theme": "^1.0.1",
-    "liquid-fire": "^0.22.0",
+    "liquid-fire": "^0.24.0",
     "ember-cli-sass": "^5.2.0"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
     "ember-ajax": "0.7.1",
+    "ember-browserify": "1.1.11",
     "ember-cli": "~2.3.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blanket": "0.9.2",
@@ -37,16 +38,17 @@
     "ember-data": "~2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-frost-core": ">=0.5.2 <2.0.0",
+    "ember-frost-core": "0.17.3",
     "ember-load-initializers": "^0.5.0",
+    "ember-lodash": "0.0.10",
+    "ember-one-way-controls": "0.8.3",
     "ember-resolver": "^2.0.3",
-    "ember-one-way-controls": "0.6.3",
+    "ember-truth-helpers": "1.2.0",
     "ember-try": "^0.2.2",
-    "loader.js": "^4.0.0",
-    "ember-lodash": "~0.0.6",
-    "ember-truth-helpers": "^1.2.0",
     "eslint": "2.9.0",
-    "eslint-config-frost-standard": "^2.0.0"
+    "eslint-config-frost-standard": "^2.0.0",
+    "loader.js": "^4.0.0",
+    "svg4everybody": "2.1.0"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -1,5 +1,5 @@
 <div class="demo-instance" >
-  <h1>Sidebar</h1>
+  <h3>Sidebar</h3>
   {{#frost-sidebar class="demo-instance"}}
     <div class="demo-pod-content">
       <h4>Test content</h4>
@@ -7,9 +7,19 @@
     </div>
   {{/frost-sidebar}}
 </div>
+<div class="demo-instance">
+  <h3>Sidebar with content expands horizontally</h3>
+  {{#frost-sidebar class="demo-instance"}}
+    <div class="demo-pod-content">
+      <h4>Pod expands based on content.</h4>
+      <h4>Horrizoooooooooootal content</h4>
+      {{frost-checkbox  checked=true label="Check me"}}
+    </div>
+  {{/frost-sidebar}}
+</div>
 
 <div class="demo-instance">
-  <h1>Sidebar with content expands horizontly</h1>
+  <h3>Sidebar with content expands horizontally beyond default 330px triggers scroll bar</h3>
   {{#frost-sidebar class="demo-instance"}}
     <div class="demo-pod-content">
       <h4>Pod expands based on content.</h4>
@@ -20,10 +30,31 @@
 </div>
 
 <div class="demo-instance">
-  <h1>Sidebar with content expands vertically</h1>
+  <h3>Sidebar with content expands vertically</h3>
   {{#frost-sidebar class="demo-instance"}}
     <div class="demo-pod-content">
       <h4>Pod expands based on content.</h4>
+      <h4>ve</h4>
+      <h4>rt</h4>
+      <h4>ic</h4>
+      <h4>al</h4>
+      {{frost-checkbox  checked=true label="Check me"}}
+    </div>
+  {{/frost-sidebar}}
+</div>
+<div class="demo-instance">
+  <h3>Sidebar with content expands vertically beyond default 550px triggers scroll bar</h3>
+  {{#frost-sidebar class="demo-instance"}}
+    <div class="demo-pod-content">
+      <h4>Pod expands based on content.</h4>
+      <h4>v</h4>
+      <h4>e</h4>
+      <h4>r</h4>
+      <h4>t</h4>
+      <h4>i</h4>
+      <h4>c</h4>
+      <h4>a</h4>
+      <h4>l</h4>
       <h4>v</h4>
       <h4>e</h4>
       <h4>r</h4>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -9,20 +9,21 @@
 </div>
 
 <div class="demo-instance">
-  <h1>Sidebar with horizontal scrollbar</h1>
+  <h1>Sidebar with content expands horizontly</h1>
   {{#frost-sidebar class="demo-instance"}}
     <div class="demo-pod-content">
-      <h4>horrizooooooooooooooooooooooooooooooooontal scroll bar</h4>
+      <h4>Pod expands based on content.</h4>
+      <h4>Horrizooooooooooooooooooooooooooooooooontal content</h4>
       {{frost-checkbox  checked=true label="Check me"}}
     </div>
   {{/frost-sidebar}}
 </div>
 
 <div class="demo-instance">
-  <h1>Sidebar with vertical scrollbar</h1>
+  <h1>Sidebar with content expands vertically</h1>
   {{#frost-sidebar class="demo-instance"}}
     <div class="demo-pod-content">
-      <h4>vertical scroll bar</h4>
+      <h4>Pod expands based on content.</h4>
       <h4>v</h4>
       <h4>e</h4>
       <h4>r</h4>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -20,5 +20,5 @@
 }
 
 .demo-instance {
-  min-height: 200px;
+  min-height: 350px;
 }

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -19,11 +19,6 @@
   z-index: $frost-z-index-notification;
 }
 
-.demo-pod-content {
-  padding: 20px;
-}
-
 .demo-instance {
-  width: 350px;
-  height: 250px;
+  min-height: 200px;
 }


### PR DESCRIPTION
#MINOR#
Aligning sidebar to ux-specs. BPSO-19076
![sidebar-hoovered](https://cloud.githubusercontent.com/assets/18577537/17061445/8af75a1c-4ffc-11e6-9af0-35b65387c94a.png)
Chrome:
![sidebar-open-chrome](https://cloud.githubusercontent.com/assets/18577537/17061447/8afa65e0-4ffc-11e6-8d25-696446f44af5.png)
Firefox:
![sidebar-open-firefox](https://cloud.githubusercontent.com/assets/18577537/17061446/8af7ce2a-4ffc-11e6-89cd-c1d23709c71b.png)
Safari:
![sidebar-open-safari](https://cloud.githubusercontent.com/assets/18577537/17061448/8afb58f6-4ffc-11e6-8ca7-6fac5c1c1f98.png)


@dafortin @d-ashfield @vesper2000 @rox163 
