### PR TITLE
Pin ember-cli-sass to version 5.4.0  to avoid issue with latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-frost-theme": "^1.0.1",
     "liquid-fire": "^0.24.0",
-    "ember-cli-sass": "^5.2.0"
+    "ember-cli-sass": "5.4.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
#PATCH#
This is to avoid issue wth latest sass version.
@job13er 
@sglanzer 