### PR TITLE
Upgrade ember-cli 2.12.3 inter-dependencies

### DIFF
--- a/blueprints/ember-frost-sidebar/index.js
+++ b/blueprints/ember-frost-sidebar/index.js
@@ -3,8 +3,8 @@ const blueprintHelper = require('ember-frost-core/blueprint-helper')
 module.exports = {
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '^1.14.3'},
-      {name: 'liquid-fire', target: '~0.26.1'}
+      {name: 'ember-frost-core', target: '1.23.10'},
+      {name: 'liquid-fire', target: '0.27.3'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.6.0",
     "ember-computed-decorators": "~0.3.0",
-    "ember-concurrency": "~0.7.15",
+    "ember-concurrency": "~0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-elsewhere": "~1.0.1",
+    "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "^0.6.0",
@@ -48,9 +48,9 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "~0.6.0",
     "ember-source": "~2.12.0",
-    "ember-spread": "^1.2.1",
+    "ember-spread": "^1.2.2",
     "ember-test-utils": "^4.0.0",
-    "ember-truth-helpers": "^1.3.0",
+    "ember-truth-helpers": "^1.2.0",
     "fixpack": "2.3.1",
     "loader.js": "^4.2.3",
     "lodash-es": "4.15.0",
@@ -64,9 +64,9 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "^5.6.0",
-    "liquid-fire": "~0.27.2",
-    "ember-frost-core": "^1.14.3"
+    "ember-cli-sass": "5.6.0",
+    "liquid-fire": "0.27.3",
+    "ember-frost-core": "1.23.10"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade ember-cli 2.12.3 inter-dependencies