### PR TITLE
Add label prop

### DIFF
--- a/addon/components/frost-sidebar.js
+++ b/addon/components/frost-sidebar.js
@@ -1,9 +1,8 @@
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, typeOf} = Ember
 import layout from '../templates/components/frost-sidebar'
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
-import {validators} from 'ember-prop-types/utils/prop-types'
 
 export default Component.extend(PropTypesMixin, {
   // == Component properties ==================================================
@@ -33,6 +32,6 @@ export default Component.extend(PropTypesMixin, {
   @readOnly
   @computed('label')
   isLabelComponent (label) {
-    return validators.EmberComponent(null, 'label', label, null, false, false)
+    return typeOf(label) !== 'string'
   }
 })

--- a/addon/components/frost-sidebar.js
+++ b/addon/components/frost-sidebar.js
@@ -1,7 +1,9 @@
 import Ember from 'ember'
 const {Component} = Ember
 import layout from '../templates/components/frost-sidebar'
+import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
+import {validators} from 'ember-prop-types/utils/prop-types'
 
 export default Component.extend(PropTypesMixin, {
   // == Component properties ==================================================
@@ -17,9 +19,20 @@ export default Component.extend(PropTypesMixin, {
       PropTypes.object,
       PropTypes.EmberObject
     ]).isRequired,
-    label: PropTypes.EmberComponent,
+    label: PropTypes.oneOfType([
+      PropTypes.EmberComponent,
+      PropTypes.string
+    ]),
 
     // Actions
     onToggle: PropTypes.func.isRequired
+  },
+
+  // == Computed Properties ===================================================
+
+  @readOnly
+  @computed('label')
+  isLabelComponent (label) {
+    return validators.EmberComponent(null, 'label', label, null, false, false)
   }
 })

--- a/addon/components/frost-sidebar.js
+++ b/addon/components/frost-sidebar.js
@@ -17,6 +17,7 @@ export default Component.extend(PropTypesMixin, {
       PropTypes.object,
       PropTypes.EmberObject
     ]).isRequired,
+    label: PropTypes.EmberComponent,
 
     // Actions
     onToggle: PropTypes.func.isRequired

--- a/addon/styles/_frost-sidebar.scss
+++ b/addon/styles/_frost-sidebar.scss
@@ -10,13 +10,19 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
-    margin-top: 5px;
-    margin-bottom: 10px;
+    margin: 5px 5px 10px 0;
+
+    .frost-sidebar-button {
+      height: 45px;
+    }
   }
 
   &-closed {
-    width: 70px;
-    height: 65px;
+    margin: 5px 5px 5px 0;
+
+    .frost-sidebar-button-label {
+      border-right: 1px solid $frost-color-lgrey-2;
+    }
   }
 
   &-content-container {
@@ -39,25 +45,28 @@
   }
 
   &-button {
-    width: 40px;
-    height: 45px;
+    display: flex;
+    align-items: center;
+    padding: 5px;
     border-radius: 4px;
     background-color: $frost-color-white;
     box-shadow: 1px 2px 5px $frost-color-grey-5;
     cursor: pointer;
     z-index: $frost-z-index-modal;
 
+    &-label {
+      margin: 0 10px;
+      padding-right: 10px;
+    }
+
     &-icon {
       width: 35px;
       height: 35px;
-      margin-top: 5px;
-      margin-right: 2px;
       vertical-align: middle;
     }
 
     &:hover {
       &:not(.frost-sidebar-button-open) {
-        width: 50px;
         padding-left: 10px;
       }
     }

--- a/addon/styles/_frost-sidebar.scss
+++ b/addon/styles/_frost-sidebar.scss
@@ -68,6 +68,7 @@
     &:hover {
       &:not(.frost-sidebar-button-open) {
         padding-left: 10px;
+        white-space: nowrap;
       }
     }
 

--- a/addon/templates/components/frost-sidebar.hbs
+++ b/addon/templates/components/frost-sidebar.hbs
@@ -17,7 +17,7 @@
       {{#if label}}
         <div class="frost-sidebar-button-label">
           {{component label
-            hook='frost-sidebar-button-label'
+            hook=(concat hook '-sidebar-button-label')
           }}
         </div>
       {{/if}}

--- a/addon/templates/components/frost-sidebar.hbs
+++ b/addon/templates/components/frost-sidebar.hbs
@@ -14,6 +14,13 @@
 {{else}}
   <div class="frost-sidebar-closed" data-test={{hook (concat hook '-sidebar')}}>
     <div class="frost-sidebar-button" {{action onToggle}} data-test={{hook (concat hook '-sidebar-button')}} role="button">
+      {{#if label}}
+        <div class="frost-sidebar-button-label">
+          {{component label
+            hook='frost-sidebar-button-label'
+          }}
+        </div>
+      {{/if}}
       {{frost-icon class="frost-sidebar-button-icon" icon="layer-normal" pack='frost-sidebar'}}
     </div>
   </div>

--- a/addon/templates/components/frost-sidebar.hbs
+++ b/addon/templates/components/frost-sidebar.hbs
@@ -16,9 +16,13 @@
     <div class="frost-sidebar-button" {{action onToggle}} data-test={{hook (concat hook '-sidebar-button')}} role="button">
       {{#if label}}
         <div class="frost-sidebar-button-label">
-          {{component label
-            hook=(concat hook '-sidebar-button-label')
-          }}
+          {{#if isLabelComponent}}
+            {{component label
+              hook=(concat hook '-sidebar-button-label')
+            }}
+          {{else}}
+            {{label}}
+          {{/if}}
         </div>
       {{/if}}
       {{frost-icon class="frost-sidebar-button-icon" icon="layer-normal" pack='frost-sidebar'}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,6 +3,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
+    babel: {
+      optional: ['es7.decorators']
+    },
     snippetSearchPaths: [
       'addon',
       'tests/dummy'

--- a/index.js
+++ b/index.js
@@ -6,6 +6,22 @@ const {setSvgConfiguration} = require('ember-frost-core/utils/frost-icon-svg')
 module.exports = {
   name: 'ember-frost-sidebar',
 
+  /* eslint-disable complexity */
+  init: function () {
+    this.options = this.options || {}
+    this.options.babel = this.options.babel || {}
+    this.options.babel.optional = this.options.babel.optional || []
+
+    if (this.options.babel.optional.indexOf('es7.decorators') === -1) {
+      this.options.babel.optional.push('es7.decorators')
+    }
+
+    /* eslint-disable no-unused-expressions */
+    this._super.init && this._super.init.apply(this, arguments)
+    /* eslint-enable no-unused-expressions */
+  },
+  /* eslint-enable complexity */
+
   included: function () {
     this.app = this._findHost.call(this) // eslint-disable-line no-useless-call
 

--- a/tests/dummy/app/pods/components/map-label/template.hbs
+++ b/tests/dummy/app/pods/components/map-label/template.hbs
@@ -1,0 +1,2 @@
+<div>Map Details</div>
+<div>Legends and symbols</div>

--- a/tests/dummy/app/pods/demo/label/controller.js
+++ b/tests/dummy/app/pods/demo/label/controller.js
@@ -1,0 +1,14 @@
+import Ember from 'ember'
+const {
+  Controller
+} = Ember
+
+export default Controller.extend({
+  sentences: ['I\'m loooooooooooooggggg content'],
+  isOpen: false,
+  actions: {
+    onToggle () {
+      this.toggleProperty('isOpen')
+    }
+  }
+})

--- a/tests/dummy/app/pods/demo/label/controller.js
+++ b/tests/dummy/app/pods/demo/label/controller.js
@@ -5,10 +5,14 @@ const {
 
 export default Controller.extend({
   sentences: ['I\'m loooooooooooooggggg content'],
-  isOpen: false,
+  isOpen1: false,
+  isOpen2: false,
   actions: {
-    onToggle () {
-      this.toggleProperty('isOpen')
+    onToggle1 () {
+      this.toggleProperty('isOpen1')
+    },
+    onToggle2 () {
+      this.toggleProperty('isOpen2')
     }
   }
 })

--- a/tests/dummy/app/pods/demo/label/template.hbs
+++ b/tests/dummy/app/pods/demo/label/template.hbs
@@ -1,0 +1,46 @@
+{{!-- BEGIN-SNIPPET label-api }}
+  {{frost-sidebar
+    ...
+    class='<class name>'
+    isOpen=<true/false>
+    content=(component '<component name>')
+    onToggle=<action>
+    label=(component '<component name>')
+    ...
+  }}
+{{ END-SNIPPET --}}
+
+<div class='addon-demo-api'>
+  <div class='addon-demo-title'>
+    Notes
+  </div>
+  <div class='addon-demo-notes'>
+    <p>
+      Pass in a label component to show beside the sidebar button.
+    </p>
+  </div>
+  <div class='addon-demo-title'>
+    API
+  </div>
+  <div class='addon-demo-snippet'>
+    {{code-snippet name='label-api.hbs'}}
+  </div>
+</div>
+<div class='addon-demo-live'>
+  <div class='addon-demo-title'>
+    Live demo
+  </div>
+  <div class='addon-demo-snippet'>
+    {{code-snippet name='label-frost-sidebar.hbs'}}
+  </div>
+  <div class='addon-demo-component'>
+    {{! BEGIN-SNIPPET label-frost-sidebar }}
+    {{frost-sidebar
+      content=(component 'simple-content' sentences=sentences)
+      onToggle=(action 'onToggle')
+      isOpen=isOpen
+      label=(component 'map-label')
+    }}
+    {{! END-SNIPPET }}
+  </div>
+</div>

--- a/tests/dummy/app/pods/demo/label/template.hbs
+++ b/tests/dummy/app/pods/demo/label/template.hbs
@@ -5,7 +5,7 @@
     isOpen=<true/false>
     content=(component '<component name>')
     onToggle=<action>
-    label=(component '<component name>')
+    label=(component '<component name>') // or string e.g. 'foo'
     ...
   }}
 {{ END-SNIPPET --}}
@@ -16,7 +16,7 @@
   </div>
   <div class='addon-demo-notes'>
     <p>
-      Pass in a label component to show beside the sidebar button.
+      Pass in a string or component to the label prop to show beside the sidebar button when it is collapsed.
     </p>
   </div>
   <div class='addon-demo-title'>
@@ -31,15 +31,32 @@
     Live demo
   </div>
   <div class='addon-demo-snippet'>
-    {{code-snippet name='label-frost-sidebar.hbs'}}
+    <i>Label component</i>  
+    {{code-snippet name='label-component-frost-sidebar.hbs'}}
   </div>
   <div class='addon-demo-component'>
-    {{! BEGIN-SNIPPET label-frost-sidebar }}
+    {{! BEGIN-SNIPPET label-component-frost-sidebar }}
     {{frost-sidebar
-      content=(component 'simple-content' sentences=sentences)
-      onToggle=(action 'onToggle')
-      isOpen=isOpen
+      content=(component 'simple-content'
+              sentences=sentences)
+      onToggle=(action 'onToggle1')
+      isOpen=isOpen1
       label=(component 'map-label')
+    }}
+    {{! END-SNIPPET }}
+  </div>
+  <div class='addon-demo-snippet'>
+    <i>String label</i>  
+    {{code-snippet name='string-label-frost-sidebar.hbs'}}
+  </div>
+  <div class='addon-demo-component'>
+    {{! BEGIN-SNIPPET string-label-frost-sidebar }}
+    {{frost-sidebar
+      content=(component 'simple-content'
+              sentences=sentences)
+      onToggle=(action 'onToggle2')
+      isOpen=isOpen2
+      label='Map Details'
     }}
     {{! END-SNIPPET }}
   </div>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -10,6 +10,7 @@
         {{#link-to 'demo.content'}}Content{{/link-to}}
         {{#link-to 'demo.size'}}Size{{/link-to}}
         {{#link-to 'demo.dynamic-updates'}}Dynamic updates{{/link-to}}
+        {{#link-to 'demo.label'}}Label component{{/link-to}}
       </div>
     {{/frost-scroll}}
   </div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function () {
     this.route('content')
     this.route('size')
     this.route('dynamic-updates')
+    this.route('label')
   })
 })
 


### PR DESCRIPTION
# Overview

## Summary
Adds a `label` prop that shows beside the button icon. Also fixes minor styling of the button

## Issue Number(s)
* Closes #38 

## Screenshots or recordings
### Label
#### Component
![sidebarlabel](https://user-images.githubusercontent.com/12944605/38956971-37387ab2-4327-11e8-887c-a869dcb221b0.gif)

#### String
<img width="186" alt="screen shot 2018-04-19 at 10 19 33 am" src="https://user-images.githubusercontent.com/12944605/38997727-20d8a9b4-43bc-11e8-9469-669f31a074e6.png">

### Button styling fix:
**Before:**
<img width="307" alt="screen shot 2018-04-18 at 2 53 36 pm" src="https://user-images.githubusercontent.com/12944605/38957005-541d0990-4327-11e8-8917-4b91c4e87b12.png">

**After:**
<img width="230" alt="screen shot 2018-04-18 at 2 52 51 pm" src="https://user-images.githubusercontent.com/12944605/38957013-590e14b2-4327-11e8-89e4-db5c98f2bb59.png">


## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [x] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork

# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#


# CHANGELOG

* Added `label` prop